### PR TITLE
Removed Mutex from PacketClient, improving async RPC performance.

### DIFF
--- a/network/rippled_base.cfg
+++ b/network/rippled_base.cfg
@@ -1,7 +1,7 @@
 [server]
 peer
-websockets_public
-port_ws_admin_local
+port_ws_public
+port_ws_admin
 rpc
 
 [peer]
@@ -9,17 +9,18 @@ port = 51235
 ip = 0.0.0.0
 protocol = peer
 
-[websockets_public]
-port = 6005
-ip = 0.0.0.0
-admin = [0.0.0.0]
-protocol = ws
-
-[port_ws_admin_local]
+[port_ws_admin]
 port = 6006
 ip = 0.0.0.0
 admin = [0.0.0.0]
 protocol = ws
+
+[port_ws_public]
+port = 6005
+ip = 0.0.0.0
+admin = [0.0.0.0]
+protocol = ws
+send_queue_limit = 500
 
 [rpc]
 port = 5005

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ use crate::peer_connector::PeerConnector;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex;
 
 /// Function that checks whether a connection between two peers should be established or not.
 ///
@@ -84,15 +83,13 @@ async fn main() -> io::Result<()> {
 
     env_logger::init();
 
-    let client = match packet_client::PacketClient::new().await {
-        Ok(client) => Arc::new(Mutex::new(client)),
+    let mut client = match packet_client::PacketClient::new().await {
+        Ok(client) => client,
         error => panic!("Error creating client: {:?}", error),
     };
 
     // Get config from controller
     let network_config = client
-        .lock()
-        .await
         .get_config()
         .await
         .expect("Could not get config from controller");

--- a/src/packet_client.rs
+++ b/src/packet_client.rs
@@ -15,6 +15,14 @@ pub struct PacketClient {
     pub client: PacketServiceClient<tonic::transport::Channel>,
 }
 
+impl Clone for PacketClient {
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+        }
+    }
+}
+
 impl PacketClient {
     /// Initializes a new PacketClient that connects to the controller.
     pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {


### PR DESCRIPTION
There was a Mutex lock on the RPC client, meaning the RPC endpoint could not be called simultaneously, even though the server supports this. Cloning the client directly (as suggested in the tonic docs) improves async performance. 